### PR TITLE
Dev

### DIFF
--- a/_projects/heart.md
+++ b/_projects/heart.md
@@ -65,7 +65,7 @@ links:
     url: 'https://hackforla.slack.com/messages/CDWKEBYBB'
   - name: Wiki
     url: 'https://github.com/hackforla/heart/wiki'
-partner: LA City Attorney’s Homeless Engagement and Response Team
+partner: LA City & County Attorney’s Homeless Engagement and Response Team
 visible: true
 vertical: 'Justice'
 status: Completed

--- a/_projects/work-for-la.md
+++ b/_projects/work-for-la.md
@@ -18,7 +18,7 @@ links:
 location: 
   - Downtown LA
   - Remote
-partner: Department of Personnel
+partner: LA City Department of Personnel
 visible: true
 status: Completed
 completed-contact: WorkForLA@googlegroups.com


### PR DESCRIPTION
I added "& County" after LA City to LA City Attorney’s Homeless Engagement and Response Team.
Fixes Update Partner Information on HfLA Website: Heart #1042. 
However, shouldn't the content also be updated on the Project Card here:
"Heart is a project working directly with the **LA City** Attorney’s Homeless Engagement and Response Team. "
Please see screenshot below:
![image](https://user-images.githubusercontent.com/81199122/113940748-ccbf6400-97b2-11eb-9bbf-5b00898ba3a0.png)
